### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.5.0
         with:
           java-version: 11
           distribution: adopt
@@ -39,15 +39,15 @@ jobs:
           gradle-version: wrapper
 
       - name: Codestyle
-        uses: fabiocapasso93/gha-kotlin-linter@v1.0
+        uses: fabiocapasso93/gha-kotlin-linter@v1.1
 
       - name: Coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2.1.0
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true
 
       - name: FOSSA
-        uses: fossas/fossa-action@v1
+        uses: fossas/fossa-action@v1.1.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: Cancel
-        uses: styfle/cancel-workflow-action@0.6.0
+        uses: styfle/cancel-workflow-action@0.9.1
         with:
           workflow_id: 'build.yml,release.yml'
           access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Setup Git
         run: |
@@ -36,7 +36,7 @@ jobs:
           GIT_EMAIL: ${{ secrets.CI_USER_GIT_EMAIL }}
 
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.5.0
         with:
           java-version: 11
           distribution: adopt


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[gradle/wrapper-validation-action](https://github.com/gradle/wrapper-validation-action)** published a new release [v1.0.4](https://github.com/gradle/wrapper-validation-action/releases/tag/v1.0.4) on 2021-05-28T13:42:22Z
* **[styfle/cancel-workflow-action](https://github.com/styfle/cancel-workflow-action)** published a new release [0.9.1](https://github.com/styfle/cancel-workflow-action/releases/tag/0.9.1) on 2021-07-29T20:59:53Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release [v2.5.0](https://github.com/actions/setup-java/releases/tag/v2.5.0) on 2021-12-21T10:41:00Z
* **[fabiocapasso93/gha-kotlin-linter](https://github.com/fabiocapasso93/gha-kotlin-linter)** published a new release [v1.1](https://github.com/TheFabbiusCorp/gha-kotlin-linter/releases/tag/v1.1) on 2020-08-16T18:26:31Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release [v2.1.0](https://github.com/codecov/codecov-action/releases/tag/v2.1.0) on 2021-09-13T13:10:33Z
* **[fossas/fossa-action](https://github.com/fossas/fossa-action)** published a new release [v1.1.0](https://github.com/fossas/fossa-action/releases/tag/v1.1.0) on 2021-09-28T16:51:13Z
